### PR TITLE
Hyphen support in handling zipcodes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ Full documentation at https://pythonhosted.org/zipcode
     >>> myzip.state     #=> 'OH'
     >>> myzip.city      #=> 'Cleveland'
     >>> 
+    >>> myzip = zipcode.isequal('44102-1234')
+    >>> myzip.state     #=> 'OH'
+    >>> myzip.city      #=> 'Cleveland'
+    >>> 
     >>> myzip.to_dict() #=>  {'zip_type': u'STANDARD', 'city': u'CLEVELAND', 'population': u'27699', 'zip': u'44102', 'yaxis': u'-0.74',     'location_text': u'Cleveland, OH', 'country': u'NA', 'notes': u'', 'lon': -81.67, 'tax_returns_filed': u'17409', 'state': u'OH', 'z    axis': u'0.66', 'location': u'NA-US-OH-CLEVELAND', 'xaxis': u'0.1', 'lat': 41.47, 'wages': u'408225500', 'decommisioned': u'FALSE',     '_LOCATION_TYPE': u'PRIMARY', 'world_region': u'NA'}
     >>>  
     >>> #all keys in the dictionary can be fetched with dot notation.
@@ -18,5 +22,3 @@ Full documentation at https://pythonhosted.org/zipcode
     >>> 
     >>> cbus = (39.98, -82.98)
     >>> zipcode.isinradius(cbus, 20) #=> list of all zip code objects within 20 miles of 'cbus'
-
-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='v2.0.7',
+    version='v2.0.8',
 
     description='A simple python package for dealing with zip codes in Python',
 

--- a/zipcode/__init__.py
+++ b/zipcode/__init__.py
@@ -6,7 +6,7 @@ import math
 __author__ = 'ConsumerAffairs.com'
 __license__ = 'MIT'
 __package__ = 'zipcode'
-__version__ = '2.0.7'
+__version__ = '2.0.8'
 
 _db_filename = 'zipcode.sql'
 _directory = os.path.dirname(os.path.abspath(__file__))

--- a/zipcode/__init__.py
+++ b/zipcode/__init__.py
@@ -127,8 +127,9 @@ def _make_zip_list(list_of_zip_tuples):
 def _validate(zipcode):
     if not isinstance(zipcode, str):
         raise TypeError('zipcode should be a string')
+    zipcode = str(zipcode).split('-')[0]
     int(zipcode)  # This could throw an error if zip is not made of numbers
-    return True
+    return zipcode
 
 
 def islike(zipcode):
@@ -136,7 +137,7 @@ def islike(zipcode):
     Takes a partial zip code and returns a list of zipcode
     objects with matching prefixes.
     """
-    _validate(zipcode)
+    zipcode = _validate(zipcode)
     _cur.execute(
         'SELECT * FROM ZIPS WHERE ZIP_CODE LIKE ?',
         ['{zipcode}%'.format(zipcode=str(zipcode))])
@@ -148,7 +149,7 @@ def isequal(zipcode):
     Takes a zipcode and returns the matching zipcode object.
     If it does not exist, None is returned
     """
-    _validate(zipcode)
+    zipcode = _validate(zipcode)
     _cur.execute('SELECT * FROM ZIPS WHERE ZIP_CODE == ?', [str(zipcode)])
     row = _cur.fetchone()
     if row:
@@ -162,11 +163,12 @@ def from_city_state(city, state):
     Takes a city and state pair and returns the matching zipcodes list.
     If it does not exist, None is returned.
     """
-    _cur.execute('SELECT * FROM ZIPS WHERE CITY == ? AND STATE == ?',
-                [str(city).upper(), str(state).upper()])
+    _cur.execute(
+        'SELECT * FROM ZIPS WHERE CITY == ? AND STATE == ?',
+        [str(city).upper(), str(state).upper()])
     rows = _cur.fetchall()
     if rows:
-        return [Zip(row) for row in rows] 
+        return [Zip(row) for row in rows]
     else:
         return None
 
@@ -186,8 +188,8 @@ def isinradius(point, distance):
 
     dist_btwn_lat_deg = 69.172
     dist_btwn_lon_deg = math.cos(point[0]) * 69.172
-    lat_degr_rad = float(distance)/dist_btwn_lat_deg
-    lon_degr_rad = float(distance)/dist_btwn_lon_deg
+    lat_degr_rad = float(distance) / dist_btwn_lat_deg
+    lon_degr_rad = float(distance) / dist_btwn_lon_deg
 
     latmin = point[0] - lat_degr_rad
     latmax = point[0] + lat_degr_rad


### PR DESCRIPTION
## Test instructions

* Open an `ipython` session at the repo's parent directory and ensure the below works for you.

```
In [1]: import zipcode

In [2]: myzip = zipcode.isequal('44102')

In [3]: myzip.state
Out[3]: u'OH'

In [4]: myzip = zipcode.isequal('44102-123a')

In [5]: myzip.state
Out[5]: u'OH'

In [6]: myzip.city
Out[6]: u'CLEVELAND'
```

- [ ] All works, no errors.

That's all, thanks!